### PR TITLE
added version check and patched for ida 9.0

### DIFF
--- a/hexcopy.py
+++ b/hexcopy.py
@@ -29,7 +29,14 @@ import idautils
 
 major, minor = map(int, idaapi.get_kernel_version().split("."))
 using_ida7api = (major > 6)
+IDA_9 = major >= 9
 using_pyqt5 = using_ida7api or (major == 6 and minor >= 9)
+
+if IDA_9:
+    import ida_kernwin
+    BWN_DISASM = ida_kernwin.BWN_DISASM
+else:
+    BWN_DISASM = idaapi.BWN_DISASMS
 
 if using_pyqt5:
     import PyQt5.QtGui as QtGui
@@ -233,7 +240,7 @@ def inject_hex_copy_actions(form, popup, form_type):
     # disassembly window
     #
 
-    if form_type == idaapi.BWN_DISASMS:
+    if form_type == BWN_DISASM:
         # insert the prefix action entry into the menu
         #
 

--- a/hexcopy.py
+++ b/hexcopy.py
@@ -27,12 +27,11 @@ import idc
 import idaapi
 import idautils
 
-major, minor = map(int, idaapi.get_kernel_version().split("."))
+major, minor = [int(v) for v in idaapi.get_kernel_version().split('.')]
 using_ida7api = (major > 6)
-IDA_9 = major >= 9
 using_pyqt5 = using_ida7api or (major == 6 and minor >= 9)
 
-if IDA_9:
+if major >= 9:
     import ida_kernwin
     BWN_DISASM = ida_kernwin.BWN_DISASM
 else:


### PR DESCRIPTION
`idaapi.BWN_DISASMS` is moved to `ida_kernwin.BWN_DISASM`
https://python.docs.hex-rays.com/ida_kernwin#bwn_disasms

_Note: for `ida_kernwin.BWN_DISASM` there is no `S` at the end as in the current working version, both have the same value `ida_kernwin.BWN_DISASM` according to the [documentation](https://python.docs.hex-rays.com/ida_kernwin#bwn_disasm), however if you try to access `ida_kernwin.BWN_DISASMS` in IDA v9.0 it does not exists._
> BWN_DISASM
> 
> ```
> BWN_DISASM = 27
> ```
> 
> BWN_DISASMS
> 
> ```
> BWN_DISASMS = 27
> ```
source: https://python.docs.hex-rays.com/ida_kernwin#bwn_disasm

to address this i've added a global constant where the value is set based on the version